### PR TITLE
Add null proxy for use when no log consumers

### DIFF
--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -91,7 +91,8 @@ sub _get_proxy_class {
     my ( $self, $proxy_name ) = @_;
     return $Log::Any::OverrideDefaultProxyClass
       if $Log::Any::OverrideDefaultProxyClass;
-    return "Log::Any::Proxy" unless $proxy_name;
+    return "Log::Any::Proxy" if !$proxy_name && _manager->has_consumer;
+    return "Log::Any::Proxy::Null" if !$proxy_name;
     my $proxy_class = (
           substr( $proxy_name, 0, 1 ) eq '+'
         ? substr( $proxy_name, 1 )

--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 package Log::Any::Manager;
+use Log::Any::Proxy::Null;
 
 our $VERSION = '1.041';
 
@@ -20,6 +21,11 @@ sub new {
     bless $self, $class;
 
     return $self;
+}
+
+sub has_consumer {
+    my ( $self ) = @_;
+    return !!( @{ $self->{entries} } || keys %{ $self->{default_adapter} } );
 }
 
 sub get_adapter {
@@ -121,6 +127,7 @@ sub set {
             sub { $self->remove($entry) unless _in_global_destruction() } );
     }
 
+    Log::Any::Proxy::Null->inflate_nulls;
     return $entry;
 }
 

--- a/lib/Log/Any/Proxy/Null.pm
+++ b/lib/Log/Any/Proxy/Null.pm
@@ -1,0 +1,46 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package Log::Any::Proxy::Null;
+
+# ABSTRACT: Log::Any generator proxy for no adapters
+our $VERSION = '1.041';
+
+use Log::Any::Adapter::Util ();
+use Log::Any::Proxy;
+our @ISA = qw/Log::Any::Proxy/;
+
+# Null proxy objects waiting for inflation into regular proxy objects
+my @nulls;
+
+sub new {
+    my $obj = shift->SUPER::new( @_ );
+    push @nulls, $obj;
+    return $obj;
+}
+
+sub inflate_nulls {
+    bless shift( @nulls ), 'Log::Any::Proxy' while @nulls;
+}
+
+my %aliases = Log::Any::Adapter::Util::log_level_aliases();
+
+# Set up methods/aliases and detection methods/aliases
+foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
+{
+    my $namef       = $name . "f";
+    my $super_name  = "SUPER::" . $name;
+    my $super_namef = "SUPER::" . $namef;
+    no strict 'refs';
+    *{$name} = sub {
+        return unless defined wantarray;
+        return shift->$super_name( @_ );
+    };
+    *{$namef} = sub {
+        return unless defined wantarray;
+        return shift->$super_namef( @_ );
+    };
+}
+
+1;

--- a/t/null-proxy.t
+++ b/t/null-proxy.t
@@ -1,0 +1,36 @@
+
+use strict;
+use warnings;
+use Test::More;
+use Log::Any;
+
+plan tests => 8;
+
+my $log = Log::Any->get_logger;
+isa_ok $log, 'Log::Any::Proxy::Null', 'no adapter proxy is Null';
+
+my $log_complex = Log::Any->get_logger(
+    category => 'Category:',
+    prefix => 'Prefix: ',
+    formatter => sub { "Formatter: @_" },
+    filter => sub { "Filter: @_" },
+);
+isa_ok $log_complex, 'Log::Any::Proxy::Null', 'no adapter proxy is Null';
+
+my $log_explicit = Log::Any->get_logger( proxy_class => 'Test' );
+isa_ok $log_explicit, 'Log::Any::Proxy::Test', 'explicit proxy class is correct';
+
+Log::Any->set_adapter( 'Test' );
+
+isa_ok $log, 'Log::Any::Proxy', 'existing logger reblessed';
+isa_ok $log_complex, 'Log::Any::Proxy', 'existing logger reblessed';
+isa_ok $log_explicit, 'Log::Any::Proxy::Test', 'explicit proxy class is not reblessed';
+
+$log->info("test");
+is Log::Any::Adapter::Test->msgs->[-1]{message}, 'test', 'log is logged';
+
+$log_complex->infof('test');
+is Log::Any::Adapter::Test->msgs->[-1]{message},
+    'Prefix: Filter: Category: 6 Formatter: Category: 6 test',
+    'proxy attributes are preserved';
+


### PR DESCRIPTION
If the program has not configured any log consumers, Log::Any should
ideally have no additional performance overhead whatsoever. This is
unrealistic, but it does mean we should reduce our overhead as much as
possible.

The null proxy improves performance about 1000% on my laptop. When the program
configures an adapter, any existing null proxy is inflated into
a regular proxy and works exactly as normal.

---

This also plays nice with #18 (#43) by going through the motions when called in non-void context. This, predictably, loses the performance improvement in that situation. Since this isn't going to be the most common use of proxy methods, it's still an improvement even if people use the new return feature.