### PR TITLE
Overloaded stringification

### DIFF
--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -8,6 +8,7 @@ package Log::Any::Proxy;
 our $VERSION = '1.043';
 
 use Log::Any::Adapter::Util ();
+use overload;
 
 sub _default_formatter {
     my ( $cat, $lvl, $format, @params ) = @_;
@@ -15,7 +16,10 @@ sub _default_formatter {
     my @new_params =
       map {
            !defined($_) ? '<undef>'
-          : ref($_)     ? Log::Any::Adapter::Util::dump_one_line($_)
+          : ref($_)     ? (
+	        overload::OverloadedStringify($_) ? "$_"
+	      : Log::Any::Adapter::Util::dump_one_line($_)
+	    )
           : $_
       } @params;
     # Perl 5.22 adds a 'redundant' warning if the number parameters exceeds

--- a/t/stringify.t
+++ b/t/stringify.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More;
+use Test::More tests => 1;
 
 {
 
@@ -27,11 +27,9 @@ my $uri = Test_URI->new('http://slashdot.org/');
 
 $log->infof( 'Fetching %s', $uri );
 
-is_deeply(
+is(
     Log::Any::Adapter::Test->msgs->[0]->{message},
     'Fetching http://slashdot.org/',
     'URI was correctly stringified'
 );
-
-done_testing;
 

--- a/t/stringify.t
+++ b/t/stringify.t
@@ -1,0 +1,23 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+
+use Log::Any '$log';
+use Log::Any::Adapter 'Test';
+
+use URI;
+
+my $uri = URI->new('http://slashdot.org/');
+
+$log->infof( 'Fetching %s', $uri );
+
+is_deeply(
+    Log::Any::Adapter::Test->msgs->[0]->{message},
+    'Fetching http://slashdot.org/',
+    'URI was correctly stringified'
+);
+
+done_testing;
+

--- a/t/stringify.t
+++ b/t/stringify.t
@@ -1,15 +1,29 @@
-#! /usr/bin/env perl
-
-use strict;
 use warnings;
+use strict;
 use Test::More;
+
+{
+
+    package Test_URI;
+
+    use overload '""' => \&stringify;
+
+    sub new {
+        my ( $class, $s ) = @_;
+        return bless { s => $s }, $class;
+    }
+
+    sub stringify {
+        my ($self) = @_;
+        return $self->{s};
+    }
+
+}
 
 use Log::Any '$log';
 use Log::Any::Adapter 'Test';
 
-use URI;
-
-my $uri = URI->new('http://slashdot.org/');
+my $uri = Test_URI->new('http://slashdot.org/');
 
 $log->infof( 'Fetching %s', $uri );
 


### PR DESCRIPTION
This patch uses `overload::OverloadedStringify` to detect whether a reference has its own stringification - cf https://metacpan.org/source/RJBS/perl-5.24.0/lib/overload.pm#L88 
If it has, it will be used instead of using Data::Dumper.

This patch would fix #48.
