### PR TITLE
Add structured logging, context data

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -135,6 +135,9 @@ IO::File = 0
 Fcntl = 0
 Test::Builder = 0
 Sys::Syslog = 0
+File::Basename = 0
+Storable = 0
+FindBin = 0
 
 [OnlyCorePrereqs]
 :version = 0.003

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -358,9 +358,10 @@ L<Data::Dumper>, and will be appended to the log message.
 
 =head2 Setting an alternate default logger
 
-When no other adapters are configured for your logger, C<Log::Any> uses
-the C<default_adapter>. To choose something other than Null as the
-default, pass it as a parameter when loading C<Log::Any>
+When no other adapters are configured for your logger, C<Log::Any>
+uses the C<default_adapter>. To choose something other than Null as
+the default, either set the C<LOG_ANY_DEFAULT_ADAPTER> environment
+variable, or pass it as a parameter when loading C<Log::Any>
 
     use Log::Any '$log', default_adapter => 'Stderr';
 

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -92,10 +92,11 @@ sub get_logger {
     }
 
     my $adapter = $class->_manager->get_adapter( $category );
+    my $context = $class->_manager->get_context();
 
     require_dynamic($proxy_class);
     return $proxy_class->new(
-        %params, adapter => $adapter, category => $category,
+        %params, adapter => $adapter, category => $category, context => $context
     );
 }
 

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -335,6 +335,27 @@ the detection methods will always return 1.
 In contrast, the default logging mechanism - Null - will return 0 for all
 detection methods.
 
+=head2 Log context data
+
+C<Log::Any> supports logging context data by exposing the C<context>
+hashref. All the key/value pairs added to this hash will be printed
+with every log message. You can localize the data so that it will be
+removed again automatically at the end of the block:
+
+    $log->context->{directory} = $dir;
+    for my $file (glob "$dir/*") {
+        local $log->context->{file} = basename($file);
+        $log->warn("Can't read file!") unless -r $file;
+    }
+
+This will produce the following line:
+
+    Can't read file! {directory => '/foo',file => 'bar'}
+
+If the configured L<Log::Any::Adapter> does not support structured
+data, the context hash will be converted to a string using
+L<Data::Dumper>, and will be appended to the log message.
+
 =head2 Setting an alternate default logger
 
 When no other adapters are configured for your logger, C<Log::Any> uses

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -283,7 +283,7 @@ You should B<not> include a newline in your message; that is the responsibility
 of the logging mechanism, which may or may not want the newline.
 
 If you want to log additional structured data alongside with your string, you
-can add a hashref to your log string. e.g.
+can add a single hashref after your log string. e.g.
 
     $log->info("program started",
         {progname => $0, pid => $$, perl_version => $]});

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -299,14 +299,15 @@ L<Log::Any::Proxy> object.
     $log->errorf("an error occurred: %s", $@);
     $log->debugf("called with %d params: %s", $param_count, \@params);
 
-By default it renders like C<sprintf>, with the following additional features:
+By default it renders like L<C<sprintf>|perlfunc/"sprintf FORMAT, LIST">,
+with the following additional features:
 
 =over
 
 =item *
 
 Any complex references (like C<\@params> above) are automatically converted to
-single-line strings with C<Data::Dumper>.
+single-line strings with L<Data::Dumper>.
 
 =item *
 
@@ -415,7 +416,7 @@ logging mechanism.
 Each of the logging mechanisms have their pros and cons, particularly in terms
 of how they are configured. For example, log4perl offers a great deal of power
 and flexibility but uses a global and potentially heavy configuration, whereas
-C<Log::Dispatch> is extremely configuration-light but doesn't handle
+L<Log::Dispatch> is extremely configuration-light but doesn't handle
 categories. There is also the unnamed future logger that may have advantages
 over either of these two, and all the custom in-house loggers people have
 created and cannot (for whatever reason) stop using.

--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -135,7 +135,11 @@ In a CPAN or other module:
     # log a string
     $log->error("an error occurred");
 
-    # log a string and data using a formatting filter
+    # log a string and some data
+    $log->info("program started",
+        {progname => $0, pid => $$, perl_version => $]});
+
+    # log a string and data using a format string
     $log->debugf("arguments are: %s", \@_);
 
     # log an error and throw an exception
@@ -278,7 +282,16 @@ C<warn> call).
 You should B<not> include a newline in your message; that is the responsibility
 of the logging mechanism, which may or may not want the newline.
 
-There are also versions of each of these methods with an additional "f" suffix
+If you want to log additional structured data alongside with your string, you
+can add a hashref to your log string. e.g.
+
+    $log->info("program started",
+        {progname => $0, pid => $$, perl_version => $]});
+
+If the configured L<Log::Any::Adapter> does not support logging structured data,
+the hash will be converted to a string using L<Data::Dumper>.
+
+There are also versions of each of the logging methods with an additional "f" suffix
 (C<infof>, C<errorf>, C<debugf>, etc.) that format a list of arguments.  The
 specific formatting mechanism and meaning of the arguments is controlled by the
 L<Log::Any::Proxy> object.

--- a/lib/Log/Any/Adapter/Development.pod
+++ b/lib/Log/Any/Adapter/Development.pod
@@ -179,7 +179,7 @@ Your adapter can choose to receive structured data instead of a
 string. In this case, instead of implementing all the L</Logging
 methods>, you define a single method called C<structured>. The method
 receives the log level, the category, and all arguments that were
-passed to the logging function, so be prepared to no only handle
+passed to the logging function, so be prepared to not only handle
 strings, but also hashrefs, arrayrefs, coderefs, etc.
 
 =head2 Aliases

--- a/lib/Log/Any/Adapter/Development.pod
+++ b/lib/Log/Any/Adapter/Development.pod
@@ -26,6 +26,13 @@ The adapter module:
        *$method = sub { ... };
    }
 
+   # or, support structured logging instead
+   sub structured {
+       my ($self, $level, $category, @args) = @_;
+       # ... process and log all @args
+   }
+
+
    # Create detection methods: is_debug, is_info, etc.
    #
    foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
@@ -121,10 +128,10 @@ through a separate C<get_logger> call, the same object will be returned.
 Therefore, you should try to avoid anything non-deterministic in your L</init>
 function.
 
-=head2 Logging methods (required)
+=head2 Logging methods
 
 The following methods have no default implementation, and MUST be defined by
-your subclass:
+your subclass, unless your adapter supports L</Structured logging>:
 
 =for :list
 * debug ($msg)
@@ -165,6 +172,15 @@ To help generate these methods programmatically, you can get a list of the
 sub names with the
 L<Log::Any::Adapter::Util::detection_methods|Log::Any::Adapter::Util/detection_methods>
 function.
+
+=head2 Structured logging
+
+Your adapter can choose to receive structured data instead of a
+string. In this case, instead of implementing all the L</Logging
+methods>, you define a single method called C<structured>. The method
+receives the log level, the category, and all arguments that were
+passed to the logging function, so be prepared to no only handle
+strings, but also hashrefs, arrayrefs, coderefs, etc.
 
 =head2 Aliases
 

--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -55,8 +55,9 @@ sub _choose_entry_for_category {
         }
     }
     # nothing requested so fallback to default
+    my $default_adapter_name = $ENV{LOG_ANY_DEFAULT_ADAPTER} || "Null";
     my $default = $self->{default_adapter}{$category}
-        || [ $self->_get_adapter_class("Null"), [] ];
+        || [ $self->_get_adapter_class($default_adapter_name), [] ];
     my ($adapter_class, $adapter_params) = @$default;
     _require_dynamic($adapter_class);
     return {

--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -16,6 +16,8 @@ sub new {
         category_cache  => {},
         # The adapter to use if no other adapter is appropriate
         default_adapter => {},
+        # The context hashref that is passed to all proxies
+        context => {},
     };
     bless $self, $class;
 
@@ -44,6 +46,11 @@ sub get_adapter {
 {
     no warnings 'once';
     *get_logger = \&get_adapter;    # backwards compatibility
+}
+
+sub get_context {
+    my ( $self ) = @_;
+    return $self->{context};
 }
 
 sub _choose_entry_for_category {

--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -52,8 +52,6 @@ sub new {
         Carp::croak("$class requires an 'category' parameter");
     }
     bless $self, $class;
-    $self->{structured_logging} =
-      $self->{adapter}->can('structured') && !$self->{filter};
     $self->init(@_);
     return $self;
 }
@@ -88,7 +86,10 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
     *{$name} = sub {
         my ( $self, @parts ) = @_;
 
-        if ( $self->{structured_logging} ) {
+        my $structured_logging =
+            $self->{adapter}->can('structured') && !$self->{filter};
+
+        if ($structured_logging) {
             unshift @parts, $self->{prefix} if $self->{prefix};
             $self->{adapter}
               ->structured( $realname, $self->{category}, @parts );
@@ -100,7 +101,7 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
             @parts = _stringify_params(@parts);
         }
         my $message = join( " ", @parts );
-        if ( length $message && !$self->{structured_logging} ) {
+        if ( length $message && !$structured_logging ) {
             $message =
               $self->{filter}->( $self->{category}, $numeric, $message )
               if defined $self->{filter};

--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -96,10 +96,12 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
             return unless defined wantarray;
         }
 
-        @parts = grep { defined($_) && length($_) } @parts, grep {scalar keys %$_} $self->{context};
-        if ( grep { ref } @parts ) {
-            @parts = _stringify_params(@parts);
-        }
+        @parts = grep { defined($_) && length($_) } @parts;
+
+        # last part might be a hashref - if so, stringify
+        push @parts, _stringify_params(pop @parts) if ( @parts && ((ref $parts[-1] || '') eq ref {}));
+
+        push @parts, _stringify_params($self->{context}) if %{$self->{context}};
         my $message = join( " ", @parts );
         if ( length $message && !$structured_logging ) {
             $message =
@@ -281,7 +283,7 @@ flexible/powerful than L</filter>, but avoids an extra function call.
 =head2 Logging Structured Data
 
 If you have data in addition to the text you want to log, you can
-specify a hashref together with your string. If the configured adapter
+specify a hashref after your string. If the configured adapter
 supports structured data, it will receive the hashref as-is, otherwise
 it will be converted to a string using L<Data::Dumper> and will be
 appended to your text.

--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -42,14 +42,18 @@ sub _default_formatter {
 
 sub new {
     my $class = shift;
-    my $self = { formatter => \&_default_formatter, context => {}, @_ };
+    my $self = { formatter => \&_default_formatter, @_ };
     unless ( $self->{adapter} ) {
         require Carp;
         Carp::croak("$class requires an 'adapter' parameter");
     }
     unless ( $self->{category} ) {
         require Carp;
-        Carp::croak("$class requires an 'category' parameter");
+        Carp::croak("$class requires a 'category' parameter");
+    }
+    unless ( $self->{context} ) {
+        require Carp;
+        Carp::croak("$class requires a 'context' parameter");
     }
     bless $self, $class;
     $self->init(@_);
@@ -63,7 +67,7 @@ sub clone {
 
 sub init { }
 
-for my $attr (qw/adapter filter formatter prefix/) {
+for my $attr (qw/adapter filter formatter prefix context/) {
     no strict 'refs';
     *{$attr} = sub { return $_[0]->{$attr} };
 }
@@ -123,11 +127,6 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
         return unless defined $message and length $message;
         return $self->$name($message);
     };
-}
-
-sub context {
-    my ($self) = @_;
-    return $self->{context};
 }
 
 1;

--- a/t/TestAdapters.pm
+++ b/t/TestAdapters.pm
@@ -1,0 +1,47 @@
+package TestAdapters;
+
+use warnings;
+use strict;
+
+our @TEXT_LOG;
+our @STRUCTURED_LOG;
+
+package TestAdapters::Normal;
+use base qw(Log::Any::Adapter::Base);
+foreach my $method ( Log::Any->logging_methods() ) {
+    no strict 'refs';
+    *$method = sub { push @TestAdapters::TEXT_LOG, $_[1] };
+}
+foreach my $method ( Log::Any->detection_methods() ) {
+    no strict 'refs';
+    *$method = sub {1};
+}
+
+package TestAdapters::Structured;
+use base qw(Log::Any::Adapter::Base);
+use Storable 'dclone';
+
+sub structured {
+    my ( $self, $level, $category, @args ) = @_;
+
+    my ( $messages, $data );
+    for (@args) {
+        if (ref) {
+            push @$data, dclone($_);
+        }
+        else {
+            push @$messages, $_;
+        }
+    }
+    my $log_hash = { level => $level, category => $category };
+    $log_hash->{messages} = $messages if $messages;
+    $log_hash->{data}     = $data     if $data;
+    push @TestAdapters::STRUCTURED_LOG, $log_hash;
+}
+
+foreach my $method ( Log::Any->detection_methods() ) {
+    no strict 'refs';
+    *$method = sub {1};
+}
+
+1;

--- a/t/context.t
+++ b/t/context.t
@@ -1,0 +1,58 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+
+use Log::Any::Adapter;
+use Log::Any '$log';
+
+use File::Basename;
+use FindBin;
+use lib $FindBin::RealBin;
+use TestAdapters;
+
+$log->context->{progname} = basename($0);
+$log->context->{pid}      = 42;
+
+sub process_dir {
+    my ($dir) = @_;
+    local $log->context->{directory} = $dir;
+    for ( 1 .. 3 ) {
+        local $log->context->{pass} = $_;
+        $log->info('Performing work');
+    }
+}
+
+Log::Any::Adapter->set('+TestAdapters::Normal');
+process_dir('/foo');
+
+Log::Any::Adapter->set('+TestAdapters::Structured');
+process_dir('/bar');
+
+my @expected_text_log = map {
+    qq(Performing work {directory => "/foo",pass => $_,pid => 42,progname => "context.t"})
+} ( 1 .. 3 );
+
+my @expected_structured_log = map {
+    {   category => 'main',
+        data     => [
+            {   directory => '/bar',
+                pass      => $_,
+                pid       => 42,
+                progname  => 'context.t'
+            }
+        ],
+        level    => 'info',
+        messages => ['Performing work']
+    }
+
+} ( 1 .. 3 );
+
+is_deeply( \@TestAdapters::TEXT_LOG, \@expected_text_log,
+    'text log is correct' );
+is_deeply( \@TestAdapters::STRUCTURED_LOG,
+    \@expected_structured_log, 'structured log is correct' );
+
+done_testing;
+

--- a/t/context.t
+++ b/t/context.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 2;
 
 use Log::Any::Adapter;
 use Log::Any '$log';
@@ -53,6 +53,3 @@ is_deeply( \@TestAdapters::TEXT_LOG, \@expected_text_log,
     'text log is correct' );
 is_deeply( \@TestAdapters::STRUCTURED_LOG,
     \@expected_structured_log, 'structured log is correct' );
-
-done_testing;
-

--- a/t/context.t
+++ b/t/context.t
@@ -15,12 +15,19 @@ use TestAdapters;
 $log->context->{progname} = basename($0);
 $log->context->{pid}      = 42;
 
+sub process_file {
+    my ($file) = @_;
+    my $log2 = Log::Any->get_logger( category => 'MyApp::FileProcessor' );
+    $log2->info('Performing work');
+}
+
 sub process_dir {
     my ($dir) = @_;
-    local $log->context->{directory} = $dir;
+    my $log1 = Log::Any->get_logger( category => 'MyApp::DirWalker' );
+    local $log1->context->{directory} = $dir;
     for ( 1 .. 3 ) {
-        local $log->context->{pass} = $_;
-        $log->info('Performing work');
+        local $log1->context->{pass} = $_;
+        process_file("$dir/$_");
     }
 }
 
@@ -35,7 +42,7 @@ my @expected_text_log = map {
 } ( 1 .. 3 );
 
 my @expected_structured_log = map {
-    {   category => 'main',
+    {   category => 'MyApp::FileProcessor',
         data     => [
             {   directory => '/bar',
                 pass      => $_,

--- a/t/default-adapter-env.t
+++ b/t/default-adapter-env.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+BEGIN { $ENV{LOG_ANY_DEFAULT_ADAPTER} = 'Test'; }
+
+use Log::Any '$log', proxy_class => 'Test';
+
+$log->err("this is an error");
+$log->contains_ok( qr/this is an error/, 'got error' );

--- a/t/structured-logging.t
+++ b/t/structured-logging.t
@@ -1,0 +1,117 @@
+use strict;
+use warnings;
+use Test::More;
+
+our @TEXT_LOG;
+our @STRUCTURED_LOG;
+
+package MyApp::Log::Normal;
+use base qw(Log::Any::Adapter::Base);
+foreach my $method ( Log::Any->logging_methods() ) {
+    no strict 'refs';
+    *$method = sub { push @main::TEXT_LOG, $_[1] };
+}
+foreach my $method ( Log::Any->detection_methods() ) {
+    no strict 'refs';
+    *$method = sub { 1 };
+}
+
+package MyApp::Log::Structured;
+use base qw(Log::Any::Adapter::Base);
+
+sub structured {
+    my ( $self, $level, $category, @args ) = @_;
+
+    my ( $messages, $data );
+    for (@args) {
+        if (ref) {
+            push @$data, $_;
+        }
+        else {
+            push @$messages, $_;
+        }
+    }
+    my $log_hash = { level => $level, category => $category };
+    $log_hash->{messages} = $messages if $messages;
+    $log_hash->{data}     = $data     if $data;
+    push @STRUCTURED_LOG, $log_hash;
+}
+
+foreach my $method ( Log::Any->detection_methods() ) {
+    no strict 'refs';
+    *$method = sub { 1 };
+}
+
+package main;
+use Log::Any::Adapter;
+
+sub create_normal_log_lines {
+    my ($log) = @_;
+
+    $log->info('some info');
+    $log->infof( 'more %s', 'info' );
+    $log->infof( 'info %s %s', { with => 'data' }, 'and more text' );
+    $log->debug( "program started",
+        { progname => "foo.pl", pid => 1234, perl_version => "5.20.0" } );
+
+}
+
+Log::Any::Adapter->set('+MyApp::Log::Normal');
+my $log = Log::Any->get_logger;
+create_normal_log_lines($log);
+
+Log::Any::Adapter->set('+MyApp::Log::Structured');
+$log = Log::Any->get_logger;
+create_normal_log_lines($log);
+$log->info(
+    'text',
+    { and => [ 'structured', 'data', of => [ arbitrary => 'depth' ] ] },
+    'and some more text'
+);
+
+is_deeply(
+    \@TEXT_LOG,
+    [
+        "some info",
+        "more info",
+        "info {with => \"data\"} and more text",
+        "program started {perl_version => \"5.20.0\",pid => 1234,progname => \"foo.pl\"}"
+    ],
+    'text log correct'
+);
+
+is_deeply(
+    \@STRUCTURED_LOG,
+    [
+        { messages => ['some info'], level => 'info', category => 'main' },
+        { messages => ['more info'], level => 'info', category => 'main' },
+        {
+            messages => ['info {with => "data"} and more text'],
+            level    => 'info',
+            category => 'main'
+        },
+        {
+            messages => ['program started'],
+            level    => 'debug',
+            category => 'main',
+            data     => [
+                { perl_version => "5.20.0", progname => "foo.pl", pid => 1234 }
+            ]
+        },
+        {
+            messages => [ 'text', 'and some more text' ],
+            data     => [
+                {
+                    and => [
+                        'structured', 'data', of => [ arbitrary => 'depth' ]
+                    ]
+                }
+            ],
+            level    => 'info',
+            category => 'main'
+        }
+    ],
+    'identical output of normal log lines when using structured log adapter'
+);
+
+done_testing;

--- a/t/structured-logging.t
+++ b/t/structured-logging.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 2;
 
 use Log::Any::Adapter;
 use Log::Any '$log';
@@ -69,5 +69,3 @@ is_deeply(
     ],
     'identical output of normal log lines when using structured log adapter'
     );
-
-done_testing;


### PR DESCRIPTION
This pull request adds three features to Log::Any, as proposed in http://blogs.perl.org/users/mephinet/2017/02/log-any-adventures.html: 

 1.  it extends the API between applications and Log::Any::Adapters to allow passing hashrefs in addition to a plain string
 1.  it allows applications to specify (possibly localized) context data for Log::Any to add to each log message
 1.  it allows system owners to globally specify a default adapter other than Null

The changes are fully backwards-compatible, and I've tried to minimize runtime overhead. In short, adapters can now implement a `structured` method instead of `warn`, `error`, `info`, etc. If they do, they will receive all arguments given to the log method, including hashrefs, without them being flattened to a string by the proxy. This allows the adapter to process the data without having to re-evaluate the string it receives.
On top of this, $log now exposes as `context` hash, where applications can add (localized) data that will be added to each log message. For non-structured adapters, the context will by Data::Dumper'ed and appended to the log line, as one would expect, whereas structured adapters will receive the unaltered hash.
The pull request also contains unittests for the new features, and the necessary documentation changes for Log::Any users and adapter developers.

To give this module a try, you can use https://github.com/mephinet/perl-Log-Any-Adapter-Screen/blob/structured-logging/lib/Log/Any/Adapter/Screen.pm as an adapter and https://gist.github.com/mephinet/c1e48e0a6d6bbd5949483e24aeac9961 as a sample application.

Please let me know what you think of these proposed changes!