### PR TITLE
when $LOG_ANY_DEFAULT_ADAPTER is set, we have a consumer

### DIFF
--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -26,7 +26,7 @@ sub new {
 
 sub has_consumer {
     my ( $self ) = @_;
-    return !!( @{ $self->{entries} } || keys %{ $self->{default_adapter} } );
+    return !!( @{ $self->{entries} } || keys %{ $self->{default_adapter} } || $ENV{LOG_ANY_DEFAULT_ADAPTER} );
 }
 
 sub get_adapter {

--- a/t/default-adapter-env.t
+++ b/t/default-adapter-env.t
@@ -1,10 +1,15 @@
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 4;
 
 BEGIN { $ENV{LOG_ANY_DEFAULT_ADAPTER} = 'Test'; }
 
-use Log::Any '$log', proxy_class => 'Test';
+use Log::Any '$log';
 
+isa_ok( $log, 'Log::Any::Proxy', 'we have a proxy...' );
+ok( !$log->isa('Log::Any::Proxy::Null'), '...but it\'s not the null proxy' );
+
+isa_ok( $log->adapter, 'Log::Any::Adapter::Test', 'correct adapter set' );
 $log->err("this is an error");
-$log->contains_ok( qr/this is an error/, 'got error' );
+$log->adapter->contains_ok( qr/this is an error/,
+    'adapter got error string' );


### PR DESCRIPTION
This commit fixes https://github.com/preaction/Log-Any/issues/59: when `$LOG_ANY_DEFAULT_ADAPTER` is set, we have a consumer, so we must create a real proxy, and not a null proxy. The original implementation of the unittest didn't catch this because it used `Log::Any::Proxy::Test`...