### PR TITLE
Add early-return if log level is disabled

### DIFF
--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -89,6 +89,7 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
     };
     *{$name} = sub {
         my ( $self, @parts ) = @_;
+        return if !$self->{adapter}->$is_realname && !defined wantarray;
 
         my $structured_logging =
             $self->{adapter}->can('structured') && !$self->{filter};


### PR DESCRIPTION
Using the optimization that is already performed in the `f` version of the log methods, to the non-`f` functions: if the log level in question is not active, and the return value of the log method is not evaluated, there's no need to do any processing here. This should result in a performance optimization without any downsides.
Solves https://github.com/preaction/Log-Any/issues/69