### PR TITLE
Allow creating Stderr, Stdout, or File adapter with "log_level => 'critical'"

### DIFF
--- a/lib/Log/Any/Adapter/File.pm
+++ b/lib/Log/Any/Adapter/File.pm
@@ -27,7 +27,7 @@ sub init {
     my $self = shift;
     if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
-        if ( !$numeric_level ) {
+        if ( !defined($numeric_level) ) {
             require Carp;
             Carp::carp( sprintf 'Invalid log level "%s". Defaulting to "%s"', $self->{log_level}, 'trace' );
         }

--- a/lib/Log/Any/Adapter/Stderr.pm
+++ b/lib/Log/Any/Adapter/Stderr.pm
@@ -18,7 +18,7 @@ sub init {
     my ($self) = @_;
     if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
-        if ( !$numeric_level ) {
+        if ( !defined($numeric_level) ) {
             require Carp;
             Carp::carp( sprintf 'Invalid log level "%s". Defaulting to "%s"', $self->{log_level}, 'trace' );
         }

--- a/lib/Log/Any/Adapter/Stdout.pm
+++ b/lib/Log/Any/Adapter/Stdout.pm
@@ -18,7 +18,7 @@ sub init {
     my ($self) = @_;
     if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
-        if ( !$numeric_level ) {
+        if ( !defined($numeric_level) ) {
             require Carp;
             Carp::carp( sprintf 'Invalid log level "%s". Defaulting to "%s"', $self->{log_level}, 'trace' );
         }


### PR DESCRIPTION
Because "critical" has a numeric value of 0, we have to test if the $numeric_level is defined rather than TRUE.
Arguable a contrived situation, and no one is likely to set the minimum log_level to "critical" but I discovered this during some testing and thought I'd provide a patch.