### PR TITLE
Capture adapter, for redirecting messages to a callback/arrayref

### DIFF
--- a/lib/Log/Any/Adapter/Capture.pm
+++ b/lib/Log/Any/Adapter/Capture.pm
@@ -1,0 +1,195 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package Log::Any::Adapter::Capture;
+
+# ABSTRACT: Adapter for capturing log messages into an arrayref
+our $VERSION = '1.708';
+
+use Log::Any::Adapter::Util ();
+
+use Log::Any::Adapter::Base;
+our @ISA = qw/Log::Any::Adapter::Base/;
+
+# Subclass for optional structured logging
+@Log::Any::Adapter::Capture::_Structured::ISA = ( __PACKAGE__ );
+
+sub init {
+    my ($self) = @_;
+
+    # Handle 'text' and 'structured' aliases
+    if ( defined $self->{text} ) {
+        $self->{format} = 'text';
+        $self->{to} = delete $self->{text};
+    }
+    if ( defined $self->{structured} ) {
+        $self->{format} = 'structured';
+        $self->{to} = delete $self->{structured};
+    }
+
+    my $to = $self->{to};
+    unless ( $to and ref $to eq 'CODE' || ref $to eq 'ARRAY' ) {
+        require Carp;
+        Carp::croak( "Capture destination 'to' must be an arrayref or coderef" );
+    }
+
+    my $format = $self->{format} || 'messages';
+    if ( $format eq 'text' ) {
+        $self->{_callback} = # only pass the message text argument
+            ref $to eq 'CODE' ? sub { $to->($_[2]) }
+            : sub { push @$to, $_[2] };
+    }
+    elsif ( $format eq 'messages' ) {
+        $self->{_callback} = ref $to eq 'CODE' ? $to : sub { push @$to, [ @_ ] };
+    }
+    elsif ( $format eq 'structured' ) {
+        $self->{_callback} = ref $to eq 'CODE' ? $to : sub { push @$to, [ @_ ] };
+        # Structured logging is determined by whether or not the package
+        # contains a method of that name.  If structured logging were enabled,
+        # the proxy would always call ->structured rather than its default
+        # behavior of flattening to a string, even for the case where the user
+        # of this module wanted strings.  So, enable/disable of structured
+        # capture requires changing the class of this object.
+        # This line is written in a way to make subclassing possible.
+        bless $self, ref($self).'::_Structured' unless $self->can('structured');
+    }
+    else {
+        require Carp;
+        Carp::croak( "Unknown capture format '$format' (expected 'text', 'messages', or 'structured')" );
+    }
+
+    if ( defined $self->{log_level} && $self->{log_level} =~ /\D/ ) {
+        my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
+        if ( !defined($numeric_level) ) {
+            require Carp;
+            Carp::carp( "Invalid log level '$self->{log_level}'.  Will capture all messages." );
+        }
+        $self->{log_level} = $numeric_level;
+    }
+}
+
+# Each logging method simply passes its arguments (minus $self) to the _callback
+# Logging can be skipped if a log_level is in effect.
+foreach my $method ( Log::Any::Adapter::Util::logging_methods() ) {
+    no strict 'refs';
+    my $method_level = Log::Any::Adapter::Util::numeric_level($method);
+    *{$method} = sub {
+        my ( $self, $text ) = @_;
+        return if defined $self->{log_level} and $method_level > $self->{log_level};
+        $self->{_callback}->( $method, $self->{category}, $text );
+    };
+}
+
+# Detection methods return true unless a log_level is in effect
+foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
+    no strict 'refs';
+    my $base = substr( $method, 3 );
+    my $method_level = Log::Any::Adapter::Util::numeric_level($base);
+    *{$method} = sub {
+        return !defined $_[0]{log_level} || !!( $method_level <= $_[0]{log_level} );
+    };
+}
+
+# A separate package is required for handling the ->structured Adapter API.
+# See notes in init()
+sub Log::Any::Adapter::Capture::_Structured::structured {
+    my ( $self, $method, $category, @parts ) = @_;
+    return if defined $self->{log_level}
+        and Log::Any::Adapter::Util::numeric_level($method) > $self->{log_level};
+    $self->{_callback}->( $method, $category, @parts );
+};
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  # temporarily redirect arrays of [ $level, $category, $message ] into an array
+  Log::Any::Adapter->set( { lexically => \my $scope }, Capture => to => \my @array );
+
+  # temporarily redirect just the text of log messages into an array
+  Log::Any::Adapter->set( { lexically => \my $scope }, Capture => text => \my @array );
+
+  # temporarily redirect the full argument list and context of each call, but only for
+  # log levels 'info' and above.
+  Log::Any::Adapter->set(
+    { lexically => \my $scope },
+    Capture =>
+        format => 'structured',
+        to => \my @array,
+        log_level => 'info'
+  );
+
+=head1 DESCRIPTION
+
+This logging adapter provides a convenient way to capture log messages into a callback
+or arrayref of your choice without needing to write your own adapter.  It is intended
+for cases where you want to temporarily capture log messages, such as showing them to
+a user of your application rather than having them written to a log file.
+
+=head1 ATTRIBUTES
+
+=head2 to
+
+Specify a coderef or arrayref where the messages will be delivered.  The content pushed onto
+the array or passed to the coderef depends on L</format>.
+
+=head2 format
+
+=over
+
+=item C<'messages'>
+
+  sub ( $level, $category, $message_text ) { ... }
+  push @to, [ $level, $category, $message_text ];
+
+This is the default format.  It passes/pushes 3 arguments: the name of the log level,
+the logging category, and the message text as a plain string.
+
+=item C<'text'>
+
+  sub ( $message_text ) { ... }
+  push @to, $message_text;
+
+This format is the simplest, and only passes/pushes the text of the message.
+
+=item C<'structured'>
+
+  sub ( $level, $category, @message_parts, \%context? ) { ... }
+  push @to, [ $level, $category, @message_parts, \%context? ];
+
+This passes/pushes the full information available about the call to the logging method.
+The C<@message_parts> are the actual arguments passed to the logging method, and if the final
+argument is a hashref, it is the combined C<context> from the logging proxy and any overrides
+passed to the logging method.
+
+=back
+
+=head2 log_level
+
+Like other logging adapters, this optional argument can filter out any log messages above the
+specified threshhold.  The default is to pass through all messages regardless of level.
+
+=head1 ATTRIBUTE ALIASES
+
+These are not actual attributes, just shortcuts for others:
+
+=head2 text
+
+  text => $dest
+
+is shorthand for
+
+  format => 'text', to => $dest
+
+=head2 structured
+
+  structured => $dest
+
+is shorthand for
+
+  format => 'structured', to => $dest
+
+=cut

--- a/t/capture.t
+++ b/t/capture.t
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+use Log::Any;
+use Log::Any::Adapter::Util qw(cmp_deeply);
+
+BEGIN { 
+    $Log::Any::OverrideDefaultProxyClass = 'Log::Any::Proxy::Test';
+}
+
+{
+
+    package Foo;
+    use Log::Any qw($log);
+
+    sub log_debug {
+        my ( $class, $text ) = @_;
+        $log->debug($text) if $log->is_debug();
+    }
+}
+{
+
+    package Bar;
+    use Log::Any qw($log);
+
+    sub log_info {
+        my ( $class, $text ) = @_;
+        $log->info($text) if $log->is_info();
+    }
+}
+
+require Log::Any::Adapter;
+
+my $main_log = Log::Any->get_logger();
+my $foo_log = $Foo::log;
+
+# redirect to array
+{
+    Log::Any::Adapter->set( { lexically => \my $scope }, Capture => to => \my @array );
+    $main_log->info('Test');
+    is_deeply( shift @array, [ 'info', 'main', 'Test' ], 'main logged to arrayref' );
+    $main_log->info('Test', 'Test2', { val => 42 });
+    is_deeply( shift @array, [ 'info', 'main', 'Test Test2 {val => 42}' ], 'main logged flattened arguments' );
+    $foo_log->trace('Test2');
+    is_deeply( shift @array, [ 'trace', 'Foo', 'Test2' ], 'Foo logged to arrayref' );
+}
+
+# redirect_to_coderef
+{
+    my @last;
+    Log::Any::Adapter->set( { lexically => \my $scope }, Capture => to => sub { @last= @_ } );
+    $main_log->info('Test');
+    is_deeply( \@last, [ 'info', 'main', 'Test' ], 'main logged to coderef' );
+    $foo_log->trace('Test2');
+    is_deeply( \@last, [ 'trace', 'Foo', 'Test2' ], 'Foo logged to coderef' );
+}
+
+# redirect text only
+{
+    Log::Any::Adapter->set(
+        { lexically => \my $scope },
+        Capture => ( text => \my @array, log_level => 'info' )
+    );
+    $main_log->info('Test');
+    is_deeply( shift @array, 'Test', 'main logged text-only to arrayref' );
+    $main_log->info('Test', 'Test2', { val => 42 });
+    is_deeply( shift @array, 'Test Test2 {val => 42}', 'main logged flattened arguments' );
+    $foo_log->trace('Test2');
+    is_deeply( shift @array, undef, 'Foo ->trace was ignored' );
+}
+
+# redirect structured
+{
+    {
+        Log::Any::Adapter->set(
+            { lexically => \my $scope },
+            Capture => ( structured => \my @array )
+        );
+        $main_log->info('Test', 'Test2', { blah => 1 });
+        is_deeply( shift @array, [ 'info', 'main', 'Test', 'Test2', { blah => 1 } ], 'main logged full data' );
+        local $main_log->context->{val} = 42;
+        $main_log->info('Test', 'Test2', { blah => 1 });
+        is_deeply( shift @array, [ 'info', 'main', 'Test', 'Test2', { blah => 1, val => 42 } ], 'main logged combined context' );
+    }
+    {
+        Log::Any::Adapter->set(
+            { lexically => \my $scope },
+            Capture => ( format => 'structured', to => \my @array )
+        );
+        $foo_log->trace('Test3', ['Test4']);
+        is_deeply( shift @array, [ 'trace', 'Foo', 'Test3', ['Test4'] ], 'Foo logged full data' );
+        local $foo_log->context->{val} = 42;
+        $foo_log->trace('Test3', ['Test4']);
+        is_deeply( shift @array, [ 'trace', 'Foo', 'Test3', ['Test4'], { val => 42 } ], 'Foo logged combined context' );
+    }
+}


### PR DESCRIPTION
This adapter is much like the 'Test' adapter, but is intended
for end users.  It can log to an arrayref or a coderef, and
has several convenient options that allow capturing the entire
structured form of a message, or just the text.  It supports a
log_level filter as well.

I've been using a simpler version of this in my projects for a
long time, specifically for the cases where a web request runs
and calls out to a module which uses Log::Any but then I want
the client to see the log messages rather than have them go to
the webserver log file.