### PR TITLE
Expose Manager->get_adapter as Adapter->get - #69

### DIFF
--- a/lib/Log/Any/Adapter.pm
+++ b/lib/Log/Any/Adapter.pm
@@ -25,6 +25,11 @@ sub remove {
     Log::Any->_manager->remove(@_)
 }
 
+sub get {
+    my $pkg = shift;
+    Log::Any->_manager->get_adapter(@_);
+}
+
 1;
 
 __END__
@@ -211,6 +216,23 @@ created will automatically adjust to the new stack. For example:
         ...
     }
     $log->error("aiggh!");   # this goes nowhere again
+
+=head1 BUILDING ON THE Log::Any BACKEND
+
+=over
+
+=item get
+
+  my $adapter= Log::Any::Adapter->get($category);
+
+The primary intended way to extend the producing-side of Log::Any is with a custom
+L<Log::Any::Proxy> class.  However, for special logging scenarios you might also
+just want access to the adapter for a given category.  The API of an adapter object
+is described in L<Log::Any::Adapter::Development>.  Beware that adapter objects can
+be "rewritten" on the fly, so any conditional behavior you write depending on the
+capabilities of an adapter must be re-checked every time you access the adapter.
+
+=back
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Making the get_adapter method public allows other logging
systems to build on Log::Any's multiplexing capability
without reaching into the inner workings.

Unrelated to my other pull request, this is a tiny change I'd like
available in the API, previously discussed in issue #69.  Feel free
to disregard it if you don't want it in the public API.

