### PR TITLE
Multiplex adapter

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -138,6 +138,7 @@ Sys::Syslog = 0
 File::Basename = 0
 Storable = 0
 FindBin = 0
+List::Util = 0
 
 [OnlyCorePrereqs]
 :version = 0.003

--- a/lib/Log/Any/Adapter/Multiplex.pm
+++ b/lib/Log/Any/Adapter/Multiplex.pm
@@ -1,0 +1,105 @@
+package Log::Any::Adapter::Multiplex;
+
+# ABSTRACT: Adapter to use allow structured logging across other adapters
+# VERSION
+
+use List::Util qw(any);
+use Log::Any;
+use Log::Any::Adapter;
+use Log::Any::Adapter::Util qw(make_method);
+use Log::Any::Manager;
+use Log::Any::Proxy;
+use Carp;
+use strict;
+use warnings;
+use base qw(Log::Any::Adapter::Base);
+
+sub init {
+    my $self = shift;
+
+    my $adapters_and_args = $self->{adapters_and_args};
+    if ( ( ref($adapters_and_args) ne 'HASH' ) ||
+         ( grep { ref($_) ne 'ARRAY' } values %$adapters_and_args ) ) {
+        Carp::croak("A list of adapters and their arguments must be provided");
+    }
+}
+
+sub structured {
+    my ($self, $level, $category, @structured_log_args) = @_;
+    my %adapters_and_args = %{ $self->{adapters_and_args} };
+    my $unstructured_log_args;
+
+    for my $adapter ( $self->_get_adapters($category) ) {
+        my $is_level = "is_$level";
+
+        if ($adapter->$is_level) {
+            # Very simple mimicry of Log::Any::Proxy
+            # We don't have to handle anything but the difference in
+            # non-structured interfaces
+            if ($adapter->can('structured')) {
+                $adapter->structured($level, $category, @structured_log_args)
+            }
+            else {
+                if (!$unstructured_log_args) {
+                    $unstructured_log_args = [
+                        _unstructured_log_args( @structured_log_args )
+                    ];
+                }
+                $adapter->$level(@$unstructured_log_args);
+            }
+        }
+    }
+}
+
+sub _unstructured_log_args {
+    my @structured   = @_;
+    my @unstructured = @structured;
+
+    if ( @structured && ( ( ref $structured[-1] ) eq ref {} ) ) {
+        @unstructured = (
+            @structured[ 0 .. $#structured - 1 ],
+            Log::Any::Proxy::_stringify_params( $structured[-1] ),
+        )
+    }
+    return @unstructured;
+}
+
+# Delegate detection methods to other adapters
+#
+foreach my $method ( Log::Any->detection_methods() ) {
+    make_method(
+        $method,
+        sub {
+            my ($self) = @_;
+            return any { $_->$method } $self->_get_adapters();
+        }
+    );
+}
+
+sub _get_adapters {
+    my ($self) = @_;
+    my $category = $self->{category};
+    # Log::Any::Manager#get_adapter has similar code
+    # But has to handle rejiggering the stack
+    # And works with one adapter at a time (instead of a list, as below)
+    # Keeping track of multiple categories here is just future-proofing.
+    #
+    my $category_cache = $self->{category_cache};
+    if ( !defined( $category_cache->{$category} ) ) {
+        my $new_cache = [];
+        my %adapters_and_args = %{ $self->{adapters_and_args} };
+        while ( my ($adapter_name, $adapter_args) = each %adapters_and_args ) {
+            my $adapter_class = Log::Any::Manager->_get_adapter_class($adapter_name);
+            push @$new_cache, $adapter_class->new(
+                @$adapter_args,
+                category => $category
+            );
+        }
+
+        $self->{category_cache}{$category} = $new_cache;
+    }
+
+    return @{ $self->{category_cache}{$category} };
+}
+
+1;

--- a/lib/Log/Any/Adapter/Multiplex.pm
+++ b/lib/Log/Any/Adapter/Multiplex.pm
@@ -103,3 +103,40 @@ sub _get_adapters {
 }
 
 1;
+
+__END__
+
+=pod
+
+=head1 SYNOPSIS
+
+    Log::Any::Adapter->set(
+        'Multiplex',
+        adapters_and_args => {
+            'Stdout' => [],
+            'Stderr' => [ log_level => 'warn' ],
+            ...
+            $adapter => \@adapter_args
+        },
+    );
+
+=head1 DESCRIPTION
+
+This built-in L<Log::Any> adapter provides a simple means of routing logs to
+multiple other L<Log::Any::Adapter>s.
+
+Adapters receiving messages from this adapter can behave just like they are the
+only recipient of the log message. That means they can, for example, use
+L<Log::Any::Adapter::Development/Structured logging> (or not).
+
+C<adapters_and_args> is a hashref whose keys should be adapters, and whose
+values are the arguments to pass those adapters on initialization.
+
+Note that this differs from other loggers like L<Log::Dispatch>, which will
+only provide its output modules a single string C<$message>, and not the full
+L<Log::Any/Log context data>.
+
+=head1 SEE ALSO
+
+L<Log::Any>, L<Log::Any::Adapter>
+

--- a/lib/Log/Any/Adapter/Multiplex.pm
+++ b/lib/Log/Any/Adapter/Multiplex.pm
@@ -3,7 +3,6 @@ package Log::Any::Adapter::Multiplex;
 # ABSTRACT: Adapter to use allow structured logging across other adapters
 # VERSION
 
-use List::Util qw(any);
 use Log::Any;
 use Log::Any::Adapter;
 use Log::Any::Adapter::Util qw(make_method);
@@ -71,7 +70,9 @@ foreach my $method ( Log::Any->detection_methods() ) {
         $method,
         sub {
             my ($self) = @_;
-            return any { $_->$method } $self->_get_adapters();
+            # Not using List::Util::any because it could break older perl builds
+            my @logging_adaptors = grep { $_->$method } $self->_get_adapters();
+            return @logging_adaptors ? 1 : 0;
         }
     );
 }

--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -171,9 +171,8 @@ sub _reselect_matching_adapters {
 
     # Reselect adapter for each category matching $pattern
     #
-    while ( my ( $category, $category_info ) =
-        each( %{ $self->{category_cache} } ) )
-    {
+    for my $category ( keys %{ $self->{category_cache} } ) {
+        my $category_info = $self->{category_cache}->{$category};
         my $new_entry = $self->_choose_entry_for_category($category);
         if ( $new_entry ne $category_info->{entry} ) {
             my $new_adapter =

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -45,7 +45,8 @@ use Log::Any::Adapter;
 
 require_ok('Log::Any::Adapter::Multiplex');
 
-subtest basic_arg_validation => sub {
+# basic_arg_validation
+{
     # helpful for making sure init() is called on each set() below
     my $log = Log::Any->get_logger;
 
@@ -89,9 +90,10 @@ subtest basic_arg_validation => sub {
     };
     ok !$@, "Multiplex set up as expected"
         or diag $@;
-};
+}
 
-subtest multiplex_implementation => sub {
+# multiplex_implementation
+{
     my %random_args = ( log_level => 'scream' );
 
     my $entry = Log::Any::Adapter->set(
@@ -155,6 +157,6 @@ subtest multiplex_implementation => sub {
     is_deeply { %_My::Unstructured::Adapter::unstructured_args },
               { },
               "unstructured adapter not called when not logging";
-};
+}
 
 done_testing();

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 16;
 
 use Log::Any;
 use Log::Any::Adapter;

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -150,7 +150,7 @@ subtest multiplex_implementation => sub {
     %_My::Unstructured::Adapter::unstructured_args = ();
     $_My::Unstructured::Adapter::is_logging = 0;
     $log->$level($message);
-    is_deeply { %_my::Unstructured::Adapter::unstructured_args },
+    is_deeply { %_My::Unstructured::Adapter::unstructured_args },
               { },
               "unstructured adapter not called when not logging";
 };

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -158,5 +158,3 @@ require_ok('Log::Any::Adapter::Multiplex');
               { },
               "unstructured adapter not called when not logging";
 }
-
-done_testing();

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -43,6 +43,8 @@ use Log::Any::Adapter;
     }
 }
 
+require_ok('Log::Any::Adapter::Multiplex');
+
 subtest basic_arg_validation => sub {
     # helpful for making sure init() is called on each set() below
     my $log = Log::Any->get_logger;

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -1,0 +1,158 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Log::Any;
+use Log::Any::Adapter;
+
+{
+    package _My::Structured::Adapter;
+    use base 'Log::Any::Adapter::Base';
+    use Log::Any::Adapter::Util qw(make_method);
+
+    our $Instance;
+    our $Is_Logging      = 0;
+    our @Structured_Args = ();
+
+    sub init { $Instance = shift }
+
+    sub structured { @Structured_Args = @_ }
+    foreach my $method ( Log::Any->detection_methods() ) {
+        make_method( $method, sub { $Is_Logging } );
+    }
+}
+
+{
+    package _My::Unstructured::Adapter;
+    use base 'Log::Any::Adapter::Base';
+    use Log::Any::Adapter::Util qw(make_method);
+
+    our $Instance;
+    our $Is_Logging        = 0;
+    our %Unstructured_Args = ();
+
+    sub init { $Instance = shift }
+
+    # Log what we called at each severity
+    foreach my $method ( Log::Any->logging_methods() ) {
+        make_method( $method, sub { $Unstructured_Args{$method} = [@_] } );
+    }
+
+    foreach my $method ( Log::Any->detection_methods() ) {
+        make_method( $method, sub { $Is_Logging } );
+    }
+}
+
+subtest basic_arg_validation => sub {
+    # helpful for making sure init() is called on each set() below
+    my $log = Log::Any->get_logger;
+
+    eval { Log::Any::Adapter->set( 'Multiplex' ) };
+    ok $@, 'adapters_and_args are required';
+
+    eval {
+        Log::Any::Adapter->set(
+            'Multiplex',
+            adapters_and_args => 'Stdout'
+        )
+    };
+    ok $@, 'adapters_and_args must be a hash';
+
+    eval {
+        Log::Any::Adapter->set(
+            'Multiplex',
+            adapters_and_args => 'Stdout'
+        )
+    };
+    ok $@, 'adapters_and_args must be a hash';
+
+    eval {
+        Log::Any::Adapter->set(
+            'Multiplex',
+            adapters_and_args => {
+                Stdout => {}
+            }
+        )
+    };
+    ok $@, 'adapters_and_args values must be arrays';
+
+    eval {
+        Log::Any::Adapter->set(
+            'Multiplex',
+            adapters_and_args => {
+                Stdout => [ log_level => 'info' ],
+                Stderr => [],
+            }
+        )
+    };
+    ok !$@, "Multiplex set up as expected"
+        or diag $@;
+};
+
+subtest multiplex_implementation => sub {
+    my %Random_Args = ( log_level => 'scream' );
+
+    my $entry = Log::Any::Adapter->set(
+        'Multiplex',
+        adapters_and_args => {
+            '+_My::Structured::Adapter'   => [ %Random_Args ],
+            '+_My::Unstructured::Adapter' => [ %Random_Args ],
+        }
+    );
+
+    my $log = Log::Any->get_logger();
+    ok !$log->is_info, "multiplex logging off for both destinations";
+
+    $_My::Structured::Adapter::Is_Logging   = 1;
+    $_My::Unstructured::Adapter::Is_Logging = 0;
+    ok $log->is_info, "multiplex logging on for one destination";
+
+    $_My::Structured::Adapter::Is_Logging   = 0;
+    $_My::Unstructured::Adapter::Is_Logging = 1;
+    ok $log->is_info, "multiplex logging on for other destination";
+
+    $_My::Structured::Adapter::Is_Logging   = 1;
+    $_My::Unstructured::Adapter::Is_Logging = 1;
+    ok $log->is_info, "multiplex logging on for both destinations";
+
+    my $structured_adapter   = $_My::Structured::Adapter::Instance;
+    my $unstructured_adapter = $_My::Unstructured::Adapter::Instance;
+
+    is $structured_adapter->{log_level},
+       $Random_Args{log_level},
+       "Arguments passed to structured adapter";
+    is $unstructured_adapter->{log_level},
+       $Random_Args{log_level},
+       "Arguments passed to unstructured adapter";
+
+    my $Message = "In a bottle";
+    my $Level   = 'info';
+    my $Cat     = __PACKAGE__;
+    $log->context->{foo} = 'bar';
+    my $Ctx_Str = '{foo => "bar"}';
+    $log->$Level($Message);
+
+    is_deeply [ @_My::Structured::Adapter::Structured_Args ],
+              [ $structured_adapter, $Level, $Cat, $Message, $log->context ],
+              "Passed appropriate structured args";
+    is_deeply $_My::Unstructured::Adapter::Unstructured_Args{$Level},
+              [ $unstructured_adapter, $Message, $Ctx_Str ],
+              "Passed appropriate unstructured args";
+
+    @_My::Structured::Adapter::Structured_Args = ();
+    $_My::Structured::Adapter::Is_Logging = 0;
+    $log->$Level($Message);
+    is_deeply [ @_My::Structured::Adapter::Structured_Args ],
+              [ ],
+              "structured adapter not called when not logging";
+
+    $_My::Structured::Adapter::Is_Logging = 1;
+    %_My::Unstructured::Adapter::Unstructured_Args = ();
+    $_My::Unstructured::Adapter::Is_Logging = 0;
+    $log->$Level($Message);
+    is_deeply { %_My::Unstructured::Adapter::Unstructured_Args },
+              { },
+              "unstructured adapter not called when not logging";
+};
+
+done_testing();


### PR DESCRIPTION
This adds a new Multiplex adapter to `Log::Any`, allowing sending messages through multiple `Log::Any::Adapters`.

The goal of this is be able to simultaneously use _structured_ logging with multiple adapters (which `Log::Any::Adapter::Dispatch` can't quite do).