### PR TITLE
Fix Multiplex context string

### DIFF
--- a/lib/Log/Any/Adapter/Multiplex.pm
+++ b/lib/Log/Any/Adapter/Multiplex.pm
@@ -25,7 +25,7 @@ sub init {
 sub structured {
     my ($self, $level, $category, @structured_log_args) = @_;
     my %adapters = %{ $self->{adapters} };
-    my $unstructured_log_args;
+    my $unstructured_msg;
 
     for my $adapter ( $self->_get_adapters($category) ) {
         my $is_level = "is_$level";
@@ -38,18 +38,16 @@ sub structured {
                 $adapter->structured($level, $category, @structured_log_args)
             }
             else {
-                if (!$unstructured_log_args) {
-                    $unstructured_log_args = [
-                        _unstructured_log_args( @structured_log_args )
-                    ];
+                if (!$unstructured_msg) {
+                    $unstructured_msg = _unstructured_msg(@structured_log_args);
                 }
-                $adapter->$level(@$unstructured_log_args);
+                $adapter->$level($unstructured_msg);
             }
         }
     }
 }
 
-sub _unstructured_log_args {
+sub _unstructured_msg {
     my @structured   = @_;
     my @unstructured = @structured;
 
@@ -59,7 +57,8 @@ sub _unstructured_log_args {
             Log::Any::Proxy::_stringify_params( $structured[-1] ),
         )
     }
-    return @unstructured;
+
+    return join(' ' => @unstructured);
 }
 
 # Delegate detection methods to other adapters

--- a/t/multiplex.t
+++ b/t/multiplex.t
@@ -140,7 +140,7 @@ require_ok('Log::Any::Adapter::Multiplex');
               [ $structured_adapter, $level, $cat, $message, $log->context ],
               "Passed appropriate structured args";
     is_deeply $_My::Unstructured::Adapter::unstructured_args{$level},
-              [ $unstructured_adapter, $message, $ctx_str ],
+              [ $unstructured_adapter, "$message $ctx_str" ],
               "Passed appropriate unstructured args";
 
     @_My::Structured::Adapter::structured_args = ();


### PR DESCRIPTION
When using Multiplex to log to unstructured adapters (like StdErr), context details were being omitted.

This makes Multiplex behave more like the standard proxy.