### PR TITLE
Add support for hooks

### DIFF
--- a/lib/Log/Any.pm
+++ b/lib/Log/Any.pm
@@ -18,6 +18,7 @@ use Log::Any::Adapter::Util qw(
   logging_and_detection_methods
   logging_methods
 );
+use Log::Any::Proxy::Util ();
 
 # This is overridden in Log::Any::Test
 our $OverrideDefaultAdapterClass;
@@ -95,10 +96,28 @@ sub get_logger {
     my $adapter = $class->_manager->get_adapter( $category );
     my $context = $class->_manager->get_context();
 
+    my $hooks_params =
+        defined $params{hooks} ? delete $params{hooks} : {};
+    my $hooks = {};
+    for my $hook_name (Log::Any::Proxy::Util::hook_names()) {
+        if( defined $hooks_params->{$hook_name} ) {
+            if( ref $hooks_params->{$hook_name} ne 'ARRAY' ) {
+                require Carp;
+                Carp::croak("Fault in hook definition: not array");
+            }
+            $hooks->{$hook_name} = $hooks_params->{$hook_name};
+        } else {
+            $hooks->{$hook_name} = [];
+        }
+    }
+
     require_dynamic($proxy_class);
-    return $proxy_class->new(
-        %params, adapter => $adapter, category => $category, context => $context
+    my $proxy = $proxy_class->new(
+        %params, adapter => $adapter, category => $category, context => $context,
+        hooks => $hooks,
     );
+    $adapter->{proxy} = $proxy;
+    return $proxy;
 }
 
 sub _get_proxy_class {

--- a/lib/Log/Any/Proxy.pm
+++ b/lib/Log/Any/Proxy.pm
@@ -67,7 +67,7 @@ sub clone {
 
 sub init { }
 
-for my $attr (qw/adapter category filter formatter prefix context/) {
+for my $attr (qw/adapter category filter formatter prefix context hooks/) {
     no strict 'refs';
     *{$attr} = sub { return $_[0]->{$attr} };
 }
@@ -108,6 +108,24 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
             my $data =
                 { map {%$_} grep {$_ && %$_} $data_from_context, $data_from_parts };
 
+            # Hooks defined when using Log::Any::Proxy
+            if( defined $self->{hooks} ) {
+                foreach my $hook (@{ $self->{hooks}->{context} }) {
+                    $hook->( $realname, $self->{category}, $data,
+                        { proxy => $self, calling_sub => $name, }
+                    );
+                }
+            }
+
+            # Hooks defined when using Log::Any::Adapter
+            my $calling_sub = (caller 0)[0] eq __PACKAGE__ ? $name.q{f} : $name;
+            if( defined $self->{adapter}->{hooks}->{proxy} ) {
+                foreach my $hook (@{ $self->{adapter}->{hooks}->{proxy} }) {
+                    $hook->( $realname, $self->{category}, $data,
+                        { proxy => $self, calling_sub => $calling_sub, }
+                    );
+                }
+            }
             if ($structured_logging) {
                 unshift @parts, $self->{prefix} if $self->{prefix};
                 $adapter->$structured_logging( $realname, $self->{category}, @parts, grep {%$_} $data );
@@ -134,6 +152,10 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
 }
 
 1;
+
+=pod
+
+=encoding utf8
 
 =head1 SYNOPSIS
 

--- a/lib/Log/Any/Proxy/Util.pm
+++ b/lib/Log/Any/Proxy/Util.pm
@@ -1,0 +1,33 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package Log::Any::Proxy::Util;
+
+# ABSTRACT: Common utility functions for Log::Any::Proxy objects
+our $VERSION = '1.721';
+
+use Exporter;
+our @ISA = qw/Exporter/;
+
+our @EXPORT_OK = qw(
+  hook_names
+);
+
+our %EXPORT_TAGS = ( );
+
+my ( @hook_names );
+
+BEGIN {
+    @hook_names                    = qw( context );
+}
+
+=sub hook_names
+
+Returns a list of hook names.
+
+=cut
+
+sub hook_names { @hook_names }
+
+1;

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use Log::Any::Adapter;
+use Log::Any qw( $log );
+use Log::Any::Adapter::Util;
+
+use FindBin;
+use lib $FindBin::RealBin;
+use TestAdapters;
+
+sub create_normal_log_lines {
+    my ($log) = @_;
+
+    $log->info('(info) some info');
+    $log->infof( '(infof) more %s', 'info' );
+    $log->infof( '(infof) info %s %s', { with => 'data' }, 'and more text' );
+    $log->debug( '(debug) program started',
+        { progname => 'foo.pl', pid => 1234, perl_version => '5.20.0' } );
+    return;
+}
+
+Log::Any::Adapter->set('+TestAdapters::Structured');
+
+my $nr_hooks = scalar @{ $log->hooks->{'context'} };
+push @{ $log->hooks->{'context'} }, \&build_context;
+create_normal_log_lines($log);
+
+sub build_context {
+    my ($lvl, $cat, $data) = @_;
+    $data->{lvl} = $lvl;
+    $data->{cat} = $cat;
+    $data->{n}    = 1;
+    return;
+}
+
+is_deeply(
+    \@TestAdapters::STRUCTURED_LOG,
+    [
+        { messages => ['(info) some info'], level => 'info', category => 'main',
+            data => [ {
+                  'cat' => 'main',
+                  'lvl' => 'info',
+                  'n' => 1,
+                }],
+        },
+        { messages => ['(infof) more info'], level => 'info', category => 'main',
+            data => [ {
+                  'cat' => 'main',
+                  'lvl' => 'info',
+                  'n' => 1,
+                }],
+        },
+        { messages => ['(infof) info {with => "data"} and more text'],
+          level    => 'info',
+          category => 'main',
+          data     => [
+              {
+                  'cat' => 'main',
+                  'lvl' => 'info',
+                  'n' => 1,
+              },
+          ],
+        },
+        {   messages => ['(debug) program started'],
+            level    => 'debug',
+            category => 'main',
+            data     => [
+                {
+                    perl_version => '5.20.0', progname => 'foo.pl', pid => 1234,
+                  'cat' => 'main',
+                  'lvl' => 'debug',
+                  'n' => 1,
+                }
+                ]
+        },
+    ],
+    'identical output of normal log lines when using structured log adapter'
+    );
+
+# Verify that after removal of the hook, things are back to normal.
+pop @{ $log->hooks->{'context'} };
+@TestAdapters::STRUCTURED_LOG = ();
+create_normal_log_lines($log);
+
+is_deeply(
+    \@TestAdapters::STRUCTURED_LOG,
+    [
+        { messages => ['(info) some info'], level => 'info', category => 'main',
+        },
+        { messages => ['(infof) more info'], level => 'info', category => 'main',
+        },
+        { messages => ['(infof) info {with => "data"} and more text'],
+          level    => 'info',
+          category => 'main',
+        },
+        {   messages => ['(debug) program started'],
+            level    => 'debug',
+            category => 'main',
+            data     => [
+                {
+                    perl_version => '5.20.0', progname => 'foo.pl', pid => 1234,
+                }
+                ]
+        },
+    ],
+    'identical output of normal log lines when using structured log adapter'
+    );


### PR DESCRIPTION
REASON:
I create logs in JSON. I want to log things like timestamp, file name and line number in every message. These change on every row. Context is very useful but to make it truly useful, there should be a way to generate it automatically. Using `filter` does not fill this need because `filter()` is not applied with structured logging. Structured logging is what I need to use when writing logs with JSON.

Hooks could fill this need. Besides, if we later decide to add more hooks, we can do it easily and in a compatible way.

EXPLANATION:
User can define a function to be called at a specific time. At the moment, there is only one hook: build_context. It is called right before passing the message and structured data to the Adapter.

The hook makes using the context easier.
Instead of defining the context every time when you call a logging function, e.g. `$log->debugf()`,
you can use the hook to define repeating information, like file name and line or timestamp.
Because the hooks support several hooked sub routines, you can add more context temporarily when you need it.

User can define the hooks either when `use`ing Log::Any or at any point afterwards.
There can be several subroutines for each hook.
They are executed in the order the hooks are added.

Examples:

    use Log::Any q($log), hooks => { build_context => [ \&build_context, ] };
    #
    push @{ $log->hooks->{'build_context'} }, \&build_more_context;