### PR TITLE
Fix stack trace scrubbing in Log::Any::Proxy::WithStackTrace

### DIFF
--- a/lib/Log/Any/Proxy/WithStackTrace.pm
+++ b/lib/Log/Any/Proxy/WithStackTrace.pm
@@ -11,24 +11,25 @@ use Log::Any::Proxy;
 our @ISA = qw/Log::Any::Proxy/;
 
 use Devel::StackTrace 2.00;
-use Devel::StackTrace::Extract qw(extract_stack_trace);
 use Log::Any::Adapter::Util ();
+use Scalar::Util qw/blessed reftype/;
 use overload;
 
 =head1 SYNOPSIS
 
   use Log::Any qw( $log, proxy_class => 'WithStackTrace' );
 
-  # Turns on argument logging in stack traces
-  use Log::Any qw( $log, proxy_class => 'WithStackTrace', proxy_show_stack_trace_args => 1 );
+  # Allow stack trace call stack arguments to be logged:
+  use Log::Any qw( $log, proxy_class => 'WithStackTrace',
+                         proxy_show_stack_trace_args => 1 );
 
-  # Some adapter that knows how to handle both structured data,
-  # and log messages which are actually objects with a
-  # "stack_trace" method:
-  #
+  # Configure some adapter that knows how to:
+  #  1) handle structured data, and
+  #  2) handle message objects which have a "stack_trace" method:
   Log::Any::Adapter->set($adapter);
 
-  $log->error("Help!");   # stack trace gets automatically added
+  $log->error("Help!");   # stack trace gets automatically added,
+                          # starting from this line of code
 
 =head1 DESCRIPTION
 
@@ -39,13 +40,20 @@ used to generate one, the resulting trace can be confusing if it begins
 relative to where the log adapter was called, and not relative to where
 the logging method was originally called.
 
-With this proxy in place, if any logging method is called with a message
-that is a non-reference scalar, that message will be upgraded into a
-C<Log::Any::MessageWithStackTrace> object with a C<stack_trace> method,
-and that method will return a trace relative to where the logging method
-was called.  A string overload is provided on the object to return the
-original message. Unless a C<proxy_show_stack_trace_args> flag is specified, arguments
-in the stack trace will be scrubbed.
+With this proxy in place, if any logging method is called with a log
+message that is a non-reference scalar (i.e. a string), that log message
+will be upgraded into a C<Log::Any::MessageWithStackTrace> object with a
+C<stack_trace> method, and that method will return a trace relative to
+where the logging method was called.  A string overload is provided on
+the object to return the original log message.
+
+Additionally, any call stack arguments in the stack trace will be
+deleted before logging, to avoid accidentally logging sensitive data.
+This happens both for message objects that were auto-generated from
+string messages, as well as for message objects that were passed in
+directly (if they appear to have a stack trace method).  This default
+argument scrubbing behavior can be turned off by specifying a true value
+for the C<proxy_show_stack_trace_args> import flag.
 
 B<Important:> This proxy should be used with a L<Log::Any::Adapter> that
 is configured to handle structured data.  Otherwise the object created
@@ -60,18 +68,16 @@ trace.
 
     use overload '""' => \&stringify;
 
-    use Carp qw( croak );
-
     sub new
     {
-        my ($class, $proxy_show_stack_trace_args, $message) = @_;
-        croak 'no "message"' unless defined $message;
+        my ($class, $message, %opts) = @_;
+
         return bless {
             message     => $message,
             stack_trace => Devel::StackTrace->new(
                 # Filter e.g "Log::Any::Proxy", "My::Log::Any::Proxy", etc.
                 ignore_package => [ qr/(?:^|::)Log::Any(?:::|$)/ ],
-                no_args => !$proxy_show_stack_trace_args,
+                no_args => $opts{no_args},
             ),
         }, $class;
     }
@@ -85,10 +91,14 @@ trace.
 
 =head2 maybe_upgrade_with_stack_trace
 
-This is an internal use method that will convert a non-reference scalar
+  @args = $self->maybe_upgrade_with_stack_trace(@args);
+
+This is an internal-use method that will convert a non-reference scalar
 message into a C<Log::Any::MessageWithStackTrace> object with a
 C<stack_trace> method.  A string overload is provided to return the
-original message. Args are scrubbed out in case they contain sensitive data,
+original message.
+
+Stack trace args are scrubbed out in case they contain sensitive data,
 unless the C<proxy_show_stack_trace_args> option has been set.
 
 =cut
@@ -97,26 +107,71 @@ sub maybe_upgrade_with_stack_trace
 {
     my ($self, @args) = @_;
 
-    # Only want a non-ref arg, optionally followed by a structured data
-    # context hashref:
-    #
-    unless ($self->{proxy_show_stack_trace_args}) {
-        for my $i (0 .. $#args) { # Check if there's a stack trace to scrub args from
-            my $trace = extract_stack_trace($args[$i]);
-            if ($trace) {
-                $self->delete_args_from_stack_trace($trace);
-                $args[$i] = $trace;
-            }
-        }
-    }
-
+    # We expect a message, optionally followed by a structured data
+    # context hashref.  Bail if we get anything other than that rather
+    # than guess what the caller might be trying to do:
     return @args unless   @args == 1 ||
                         ( @args == 2 && ref $args[1] eq 'HASH' );
-    return @args if ref $args[0];
 
-    $args[0] = Log::Any::MessageWithStackTrace->new($self->{proxy_show_stack_trace_args}, $args[0]);
+    if (ref $args[0]) {
+        $self->maybe_delete_stack_trace_args($args[0])
+            unless $self->{proxy_show_stack_trace_args};
+    }
+    else {
+        $args[0] = Log::Any::MessageWithStackTrace->new(
+            $args[0],
+            no_args => !$self->{proxy_show_stack_trace_args},
+        );
+    }
 
     return @args;
+}
+
+=head2 maybe_delete_stack_trace_args
+
+  $self->maybe_delete_stack_trace_args($arg);
+
+This is an internal-use method that, given a single argument that is a
+reference, tries to figure out whether the argument is an object with a
+stack trace, and if so tries to delete any stack trace args.
+
+The logic is based on L<Devel::StackTrace::Extract>.
+
+It specifically looks for objects with a C<stack_trace> method (which
+should catch anything that does L<StackTrace::Auto>, including anything
+that does L<Throwable::Error>), or a C<trace> method (used by
+L<Exception::Class> and L<Moose::Exception> and friends).
+
+It specifically ignores L<Mojo::Exception> objects, because their stack
+traces don't contain any call stack args.
+
+=cut
+
+sub maybe_delete_stack_trace_args
+{
+    my ($self, $arg) = @_;
+
+    return unless blessed $arg;
+
+    if ($arg->can('stack_trace')) {
+        # This should catch anything that does StackTrace::Auto,
+        # including anything that does Throwable::Error.
+        my $trace = $arg->stack_trace;
+        $self->delete_args_from_stack_trace($trace);
+    }
+    elsif ($arg->isa('Mojo::Exception')) {
+        # Skip these, they don't have args in their stack traces.
+    }
+    elsif ($arg->can('trace')) {
+        # This should catch Exception::Class and Moose::Exception and
+        # friends.  Make sure to check for the "trace" method *after*
+        # skipping the Mojo::Exception objects, because those also have
+        # a "trace" method.
+        my $trace = $arg->trace;
+        $self->delete_args_from_stack_trace($trace);
+    }
+
+    return;
 }
 
 my %aliases = Log::Any::Adapter::Util::log_level_aliases();
@@ -137,10 +192,11 @@ foreach my $name ( Log::Any::Adapter::Util::logging_methods(), keys(%aliases) )
 
 =head2 delete_args_from_stack_trace($trace)
 
-    $self->delete_args_from_stack_trace($trace)
+  $self->delete_args_from_stack_trace($trace)
 
-To scrub potentially sensitive data from C<Devel::StackTrace> arguments, this method deletes
-arguments from all of the C<Devel::StackTrace::Frame> in the trace.
+To scrub potentially sensitive data from C<Devel::StackTrace> arguments,
+this method deletes arguments from all of the C<Devel::StackTrace::Frame>
+in the trace.
 
 =cut
 
@@ -148,11 +204,14 @@ sub delete_args_from_stack_trace
 {
     my ($self, $trace) = @_;
 
-    return unless $trace;
+    return unless $trace && $trace->can('frames');
 
     foreach my $frame ($trace->frames) {
+        next unless $frame->{args};
         $frame->{args} = [];
     }
+
+    return;
 }
 
 1;

--- a/t/proxy-with-stack-trace.t
+++ b/t/proxy-with-stack-trace.t
@@ -4,35 +4,49 @@ use warnings;
 use Test::More;
 use List::Util qw( any );
 use Log::Any;
-
-plan tests => 61;
+use Scalar::Util qw( blessed );
+use Storable qw( dclone );
 
 use FindBin;
 use lib $FindBin::RealBin;
 use TestAdapters;
 
+my (
+    $num_tests,
+    $have_Mojo_Exception,
+    $have_Moose_Exception,
+    $have_Throwable_Error,
+);
 BEGIN {
+
+    $num_tests = 152;
+    eval {
+        require Mojo::Exception;
+        $have_Mojo_Exception = 1;
+        $num_tests += 27;
+    };
+    eval {
+        require Throwable::Error;
+        $have_Throwable_Error = 1;
+        $num_tests += 31;
+    };
+    eval {
+        require Moose::Exception;
+        $have_Moose_Exception = 1;
+        $num_tests += 31;
+    };
+
     eval {
         require Devel::StackTrace;
         Devel::StackTrace->VERSION( 2.00 );
     };
     if ( $@ ) {
         plan skip_all => 'Devel::StackTrace >= 2.00 is required for this test';
-    }
-    eval {
-        require Storable;
-        Storable->VERSION( 3.08 );
-    };
-    if ( $@ ) {
-        plan skip_all => 'Storable >= 3.08 is required for this test';
-    }
-    eval {
-        require Devel::StackTrace::Extract;
-    };
-    if ( $@ ) {
-        plan skip_all => 'Devel::StackTrace::Extract is required for this test';
+        $num_tests = 0;
     }
 }
+
+plan tests => $num_tests if $num_tests;
 
 use Log::Any::Proxy::WithStackTrace;    # necessary?
 
@@ -62,10 +76,16 @@ Log::Any->set_adapter('+TestAdapters::Structured');
 
 is ref $default_log,   'Log::Any::Proxy',
     'existing default proxy is reblessed after adapter';
+is !!$default_log->{proxy_show_stack_trace_args}, '',
+    'Defauly log does not proxy_show_stack_trace_args';
 is ref $log,           'Log::Any::Proxy::WithStackTrace',
     'existing explicit proxy is still WithStackTrace after adapter';
+is !!$log->{proxy_show_stack_trace_args}, '',
+    'WithStackTrace does not proxy_show_stack_trace_args';
 is ref $log_show_args, 'Log::Any::Proxy::WithStackTrace',
     'existing explicit proxy with proxy_show_stack_trace_args flag is still WithStackTrace after adapter';
+is !!$log_show_args->{proxy_show_stack_trace_args}, 1,
+    'WithStackTrace does proxy_show_stack_trace_args';
 
 is ref $default_log->adapter,   'TestAdapters::Structured',
     'existing default proxy has correct adapter';
@@ -74,102 +94,352 @@ is ref $log->adapter,           'TestAdapters::Structured',
 is ref $log_show_args->adapter, 'TestAdapters::Structured',
     'existing explicit proxy with proxy_show_stack_trace_args flag has correct adapter';
 
-my @test_cases = (
-    [
-        'simple',
-        [ 'test' ],
-        'test',
-    ],
-    [
-        'with structured data',
-        [ 'test', { foo => 1 } ],
-        'test',
-    ],
-    [
-        'formatted',
-        [ 'test %s', 'extra' ],
-        'test extra',
-    ],
-);
+###################################################################
 
-sub check_test_cases {
-    foreach my $test_case (@test_cases) {
-        my ($desc, $args, $expected) = @$test_case;
+# Dummy default for initial call:
+my $logger     = $default_log;
+my $message    = "dummy";
+my $extra_args = [];
 
-        my $is_formatted = $args->[0] =~ /%/;
+my ($Mojo_Exception, $Moose_Exception, $Throwable_Error);
 
-        my $method = $is_formatted ? 'infof' : 'info';
+sub foo
+{
+    sub bar {
 
-        my ($msgs, $msg);
+        # Log with a stack trace that is 3 frames deep (main->foo->bar):
+        $logger->info($message, @$extra_args);
 
-        my $type = 'default';
-
-        @TestAdapters::STRUCTURED_LOG = ();
-        $default_log->$method(@$args);
-        $msgs = \@TestAdapters::STRUCTURED_LOG;
-        is @$msgs, 1, "$desc expected number of structured messages from $type logger";
-        is $msgs->[0]->{category}, 'main',
-            "$desc expected category from $type logger";
-        is $msgs->[0]->{level}, 'info',
-            "$desc expected level from $type logger";
-        $msg = $msgs->[0]->{messages}->[0];  # "messages" for text
-        is $msg, $expected,
-            "$desc expected message from $type logger";
-
-        $type = 'stack trace';
-
-        @TestAdapters::STRUCTURED_LOG = ();
-        $log->$method(@$args);
-        $msgs = \@TestAdapters::STRUCTURED_LOG;
-        is @$msgs, 1, "$desc expected number of structured messages from $type logger";
-        is $msgs->[0]->{category}, 'main',
-            "$desc expected category from $type logger";
-        is $msgs->[0]->{level}, 'info',
-            "$desc expected level from $type logger";
-        $msg = $msgs->[0]->{data}->[0];  # "data" for non-text
-        is ref $msg, 'Log::Any::MessageWithStackTrace',
-            "$desc expected message object from $type logger";
-        is "$msg", $expected,
-            "$desc expected stringified message from $type logger";
-        my $trace = $msg->stack_trace;
-        is ref $trace, 'Devel::StackTrace',
-            "$desc expected stack_trace object from $type logger";
-        is $trace->frame_count, 2,
-            "$desc stack_trace object has expected number of frames from $type logger";
-        #  first frame should be the call to "info" inside this sub (19 lines up),
-        # second frame should be the call to this sub from main
-        is $trace->frame(0)->line, __LINE__ - 19,
-            "$desc stack_trace object has expected first frame from $type logger";
-        is $trace->frame(1)->subroutine, 'main::check_test_cases',
-            "$desc stack_trace object has expected second frame from $type logger";
-        if (!$is_formatted && @$args > 1) {
-            my $more_data = $msgs->[0]->{data}->[1];
-            is_deeply $more_data, $args->[1],
-                "expected structured data from $type logger";
-        }
-        foreach my $frame ($trace->frames) {
-            is scalar @{ $frame->{args} }, 0,
-                "stack_trace frame does not have args by default";
+        # Create a Mojo::Exception with a similar stack trace:
+        if ($have_Mojo_Exception && !$Mojo_Exception) {
+            local $@;
+            eval { Mojo::Exception->throw("Help!") };
+            $Mojo_Exception = $@;
         }
 
-        @TestAdapters::STRUCTURED_LOG = ();
-        $log_show_args->$method(@$args);
-        $msgs = \@TestAdapters::STRUCTURED_LOG;
-        $msg = $msgs->[0]->{data}->[0];  # "data" for non-text
+        # Create a Moose::Exception with a similar stack trace:
+        if ($have_Moose_Exception && !$Moose_Exception) {
+            $Moose_Exception = Moose::Exception->new(message => "Help!");
+        }
 
-        $trace = $msg->stack_trace;
-
-        ok(
-            any (
-                sub {
-                    ($_->args >= 1);
-                },
-                $trace->frames
-            ),
-            "stack_trace frame has args if proxy_show_stack_trace_args => 1 is passed to logger",
-        );
+        # Create a Throwable::Error with a similar stack trace:
+        if ($have_Throwable_Error && !$Throwable_Error) {
+            local $@;
+            eval { Throwable::Error->throw("Help!") };
+            $Throwable_Error = $@;
+            # Default log adapter doesn't like coderefs:
+            $Throwable_Error->stack_trace->{frame_filter} = undef;
+            $Throwable_Error->{stack_trace_args}          = undef;
+        }
     }
+
+    bar("quux");
 }
 
-check_test_cases();
+# Make sure exception objects get initialized:
+foo("bar", "baz") if $have_Mojo_Exception  ||
+                     $have_Moose_Exception ||
+                     $have_Throwable_Error;
+
+my ($desc, $expected_by_type);
+
+foreach my $t (
+    [
+        "with string",
+        "Help!",
+        [],
+        {
+            "default log" => "Help!",
+            "proxy log" => [
+                "Help!",
+                "Log::Any::MessageWithStackTrace",
+            ],
+            "proxy log show args" => [
+                "Help!",
+                "Log::Any::MessageWithStackTrace",
+            ],
+        },
+    ],
+    [
+        "with string and extra args",
+        "Help!",
+        [ {extra => "data"} ],
+        {
+            "default log" => "Help!",
+            "proxy log" => [
+                "Help!",
+                "Log::Any::MessageWithStackTrace",
+            ],
+            "proxy log show args" => [
+                "Help!",
+                "Log::Any::MessageWithStackTrace",
+            ],
+        },
+    ],
+    [
+        "with string and bad extra args",
+        "Help!",
+        [ {extra => "data"}, "huh?" ],
+        {
+            "default log"         => "Help!",
+            # no automatic object inflation if unexpected args:
+            "proxy log"           => "Help!",
+            "proxy log show args" => "Help!",
+        },
+    ],
+    [
+        "with string and bad non-hashref extra args",
+        "Help!",
+        [ "huh?" ],
+        {
+            "default log"         => "Help!",
+            # no automatic object inflation if unexpected args:
+            "proxy log"           => "Help!",
+            "proxy log show args" => "Help!",
+        },
+    ],
+    [
+        "with non-string unblessed message",
+        {foo => "bar"},
+        [],
+        {
+            "default log" => [
+                {foo => "bar"},
+                "HASH",
+            ],
+            # no automatic object inflation if non-string message:
+            "proxy log" => [
+                {foo => "bar"},
+                "HASH",
+            ],
+            "proxy log show args" => [
+                {foo => "bar"},
+                "HASH",
+            ],
+        },
+    ],
+    [
+        "with dummy blessed object",
+        bless({foo => "bar"}, "DummyError"),
+        [],
+        {
+            "default log" => [
+                qr{^DummyError=HASH\(0x[0-9a-f]+\)},
+                "DummyError",
+            ],
+            # no automatic object inflation if random blessed message:
+            "proxy log" => [
+                qr{^DummyError=HASH\(0x[0-9a-f]+\)},
+                "DummyError",
+            ],
+            "proxy log show args" => [
+                qr{^DummyError=HASH\(0x[0-9a-f]+\)},
+                "DummyError",
+            ],
+        },
+    ],
+    [
+        "with Mojo::Exception message",
+        $Mojo_Exception,
+        [],
+        {
+            "default log" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\.},
+                "Mojo::Exception",
+            ],
+            "proxy log" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\.},
+                "Mojo::Exception",
+            ],
+            "proxy log show args" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\.},
+                "Mojo::Exception",
+            ],
+        },
+    ],
+    [
+        "with Moose::Exception message",
+        $Moose_Exception,
+        [],
+        {
+            "default log" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\n},
+                "Moose::Exception",
+            ],
+            "proxy log" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\n},
+                "Moose::Exception",
+            ],
+            "proxy log show args" => [
+                qr{^Help! at t/proxy-with-stack-trace\.t line \d+\n},
+                "Moose::Exception",
+            ],
+        },
+    ],
+    [
+        "with Throwable::Error message",
+        $Throwable_Error,
+        [],
+        {
+            "default log" => [
+                qr{^Help!\n\nTrace begun at t/proxy-with-stack-trace\.t line \d+\n},
+                "Throwable::Error",
+            ],
+            "proxy log" => [
+                qr{^Help!\n\nTrace begun at t/proxy-with-stack-trace\.t line \d+\n},
+                "Throwable::Error",
+            ],
+            "proxy log show args" => [
+                qr{^Help!\n\nTrace begun at t/proxy-with-stack-trace\.t line \d+\n},
+                "Throwable::Error",
+            ],
+        },
+    ],
+) {
+    my $orig_message;
+    ($desc, $orig_message, $extra_args, $expected_by_type) = @$t;
+
+    # This can happen if one of the optional exception modules is not
+    # loaded:
+    next unless $orig_message;
+
+    foreach my $type (sort keys %$expected_by_type) {
+
+        $message = ref $orig_message ? dclone $orig_message : $orig_message;
+
+        $logger = {
+            "default log"         => $default_log,
+            "proxy log"           => $log,
+            "proxy log show args" => $log_show_args,
+        }->{$type};
+
+        @TestAdapters::STRUCTURED_LOG = ();
+        foo("bar", "baz");
+
+        my $logged = \@TestAdapters::STRUCTURED_LOG;
+
+        my $long_desc = "$type $desc";
+
+        is @$logged, 1,
+            "$long_desc - got expected number of log messages";
+        my $msg = $logged->[0];
+        is $msg->{category}, 'main',
+            "$long_desc - got expected category";
+        is $msg->{level}, 'info',
+            "$long_desc - got expected level";
+
+        my $expected = $expected_by_type->{$type};
+
+        if (ref $expected) {
+            my $messages = $msg->{messages};
+            is $messages, undef,
+                "$long_desc - got expected number of structured messages";
+            my $data = $msg->{data};
+            if (@$extra_args == 0) {
+                is @$data, 1,
+                    "$long_desc - got expected number of structured data";
+            }
+            elsif (@$extra_args == 1 && ref $extra_args->[0] eq 'HASH') {
+                is @$data, 2,
+                    "$long_desc - got expected number of structured data";
+                is_deeply $data->[1], $extra_args->[0],
+                    "$long_desc - got expected extra structured data";
+            }
+            else {
+                is $data, undef,
+                    "$long_desc - got expected number of structured data";
+            }
+            my $thing = $data->[0];
+            my $blessed = blessed $thing;
+
+            my $expected_value = $expected->[0];
+            my $expected_type  = $expected->[1];
+
+            if ($blessed || ! ref $expected_value) {
+
+                if (ref $expected_value eq 'Regexp') {
+                    like "$thing", $expected_value,
+                        "$long_desc - message stringifies correctly";
+                }
+                else {
+                    is "$thing", $expected_value,
+                        "$long_desc - message stringifies correctly";
+                }
+            }
+            is ref $thing, $expected_type,
+                "$long_desc - expected type of structured data got logged";
+
+            my (@frames, $stack_trace);
+            if ($blessed) {
+                @frames = $thing->can("frames") ? $thing->frames : ();
+                unless (@frames) {
+                    $stack_trace = $thing->can("stack_trace")
+                                       ? $thing->stack_trace
+                                       : $thing->can("trace")
+                                           ? $thing->trace : undef;
+                    @frames = $stack_trace->frames if $stack_trace;
+                }
+            }
+            if (@frames) {
+
+                # Mojo::Exception returns a listref istead of a list:
+                @frames = @{$frames[0]} if @frames == 1 &&
+                                           ref $frames[0] eq 'ARRAY';
+
+                my $frame = $frames[-1];
+                my $sub = $expected_type eq "Mojo::Exception"
+                              ? $frame->[3] : $frame->subroutine;
+                is $sub, "main::foo",
+                    "$long_desc - first frame has correct sub";
+                unless ($expected_type eq "Mojo::Exception") {
+                    if ($type eq "proxy log") {
+                        is_deeply [$frame->args], [],
+                            "$long_desc - first frame has expected args";
+                    }
+                    elsif ($type eq "proxy log show args") {
+                        is_deeply [$frame->args], ["bar","baz"],
+                            "$long_desc - first frame has expected args";
+                    }
+                }
+                $frame = $frames[-2];
+                $sub = $expected_type eq "Mojo::Exception"
+                           ? $frame->[3] : $frame->subroutine;
+                is $sub, "main::bar",
+                    "$long_desc - second frame has correct sub";
+                unless ($expected_type eq "Mojo::Exception") {
+                    if ($type eq "proxy log") {
+                        is_deeply [$frame->args], [],
+                            "$long_desc - second frame has expected args";
+                    }
+                    elsif ($type eq "proxy log show args") {
+                        is_deeply [$frame->args], ["quux"],
+                            "$long_desc - second frame has expected args";
+                    }
+                }
+            }
+        }
+        else {
+            my $messages = $msg->{messages};
+            my @expected = ($expected);
+            push @expected, $extra_args->[0] if $extra_args->[0] &&
+                                            ref $extra_args->[0] ne 'HASH';
+            push @expected, $extra_args->[1] if $extra_args->[1];
+            is @$messages, @expected,
+                "$long_desc - got expected number of structured messages";
+            is_deeply $messages, \@expected,
+                "$long_desc - expected structured message got logged";
+            my $data = $msg->{data};
+            if (ref $extra_args->[0] eq 'HASH') {
+                is @$data, 1,
+                    "$long_desc - got expected number of structured data";
+                is_deeply $data->[0], $extra_args->[0],
+                    "$long_desc - got expected structured data";
+            }
+            else {
+                is $data, undef,
+                    "$long_desc - got expected number of structured data";
+            }
+        }
+    }
+}
 


### PR DESCRIPTION
The previous logic was all wrong - it extracted the stack trace from any exception objects sent as log messages, and scrubbed them, but then threw away the exception objects entirely and just sent the stack trace as if it was the log message.  The new logic logic scrubs the stack traces in-place within the exception objects.