### PR TITLE
t: Require Storable >= 3.06 for t/proxy-with-stack-trace.t

### DIFF
--- a/t/proxy-with-stack-trace.t
+++ b/t/proxy-with-stack-trace.t
@@ -44,6 +44,14 @@ BEGIN {
         plan skip_all => 'Devel::StackTrace >= 2.00 is required for this test';
         $num_tests = 0;
     }
+    eval {
+        require Storable;
+        Storable->VERSION( 3.06 );
+    };
+    if ( $@ ) {
+        plan skip_all => 'Storable >= 3.06 is required for this test';
+        $num_tests = 0;
+    }
 }
 
 plan tests => $num_tests if $num_tests;


### PR DESCRIPTION
Otherwise we'll get

    Can't store REGEXP items

Fixes #102