### PR TITLE
Ensure adapter is available during global destruction

### DIFF
--- a/lib/Log/Any/Manager.pm
+++ b/lib/Log/Any/Manager.pm
@@ -35,7 +35,11 @@ sub get_adapter {
     # Create a new adapter for this category if it is not already in cache
     #
     my $category_cache = $self->{category_cache};
-    if ( !defined( $category_cache->{$category} ) ) {
+
+    # The order in which objects are destroyed during the global destruction
+    # before the program exits is unpredictable.
+    # {adapter} is an object, so already at this point it can be undef!
+    if ( !defined( $category_cache->{$category} ) || !defined( $category_cache->{$category}->{adapter} )) {
         my $entry = $self->_choose_entry_for_category($category);
         my $adapter = $self->_new_adapter_for_entry( $entry, $category );
         $category_cache->{$category} = { entry => $entry, adapter => $adapter };


### PR DESCRIPTION
I am developing a testing tool which creates testing resources and then collects them when their reference count goes to zero. This means my code has a lot of activity in DESTRUCT phase. Often the DESTROY methods get executed only at the end of the program. So they go into global destruction. I was often receiving these errors:

    (in cleanup) Log::Any::Proxy requires an 'adapter' parameter at [..]/Log/Any/Proxy.pm

... but not every time!

When I specifically reclaimed my objects by `undef`'ing them or by letting them fall out of subroutine scope, the problem disappeared.


Global Destruction

The order in which objects are destroyed during the global destruction before the program exits is unpredictable. This means that any objects contained by your object may already have been destroyed. You should check that a contained object is defined before calling a method on it:

-- https://perldoc.perl.org/perlobj#Global-Destruction